### PR TITLE
Fix stray dependency field

### DIFF
--- a/package.json
+++ b/package.json
@@ -49,8 +49,7 @@
     "react-native-screens": "~4.4.0",
     "react-native-svg": "^15.11.2",
     "react-native-web": "~0.19.13",
-    "react-native-webview": "13.12.5",
-    "undefined": "expo-auth-session/providers/google"
+    "react-native-webview": "13.12.5"
   },
   "devDependencies": {
     "@babel/core": "^7.25.2",


### PR DESCRIPTION
## Summary
- remove invalid `undefined` dependency entry from `package.json`

## Testing
- `npm test --silent` *(fails: jest not found)*

------
https://chatgpt.com/codex/tasks/task_e_68563c43abb0832b953cb1b198b0787f