### PR TITLE
Implement chat read receipts and access control

### DIFF
--- a/firestore.rules
+++ b/firestore.rules
@@ -12,8 +12,17 @@ service cloud.firestore {
       // Deletion only by creator
       allow delete: if request.auth.uid == resource.data.creatorId;
     }
+    function isParticipant(chatId) {
+      return request.auth != null &&
+        request.auth.uid in get(/databases/$(database)/documents/chats/$(chatId)).data.participants;
+    }
     match /chats/{chatId} {
-      allow read, write: if request.auth != null;
+      allow create: if request.auth != null && request.auth.uid in request.resource.data.participants;
+      allow read, update, delete: if isParticipant(chatId);
+      match /messages/{messageId} {
+        allow create: if isParticipant(chatId);
+        allow read, update, delete: if isParticipant(chatId);
+      }
     }
     match /users/{userId} {
       allow read: if true;


### PR DESCRIPTION
## Summary
- restrict chat access in Firestore rules to only participants
- add read receipt handling in `ChatDrawer` and `[chatId]` chat screen
- show read status with a checkmark icon

## Testing
- `npm test` *(fails: jest not found)*

------
https://chatgpt.com/codex/tasks/task_e_6856d15063fc832bae0db75f47a413d2